### PR TITLE
fix: #42 location is not defined in SSR mode

### DIFF
--- a/.changeset/silly-ghosts-drop.md
+++ b/.changeset/silly-ghosts-drop.md
@@ -1,0 +1,5 @@
+---
+"@passerelle/core": patch
+---
+
+fix: #42 location is not defined in SSR mode

--- a/packages/core/src/communicator.ts
+++ b/packages/core/src/communicator.ts
@@ -56,6 +56,7 @@ export class Communicator {
     this.#senderWindow = senderWindow
     this.#config = {
       ...defaultConfig,
+      origin: location.host,
       ...omitNil(config)
     } as FixedConfig
     this.#validateConfig(this.#config)

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -50,4 +50,4 @@ export const defaultConfig = {
 } as const satisfies CommunicateConfig
 Object.freeze(defaultConfig)
 
-export type FixedConfig = CommunicateConfig & typeof defaultConfig
+export type FixedConfig = CommunicateConfig & typeof defaultConfig & { origin: string }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -45,8 +45,8 @@ export interface CommunicateConfig {
 
 export const defaultConfig = {
   collabRequestTimeout: 1000,
-  requireCollab: false,
-  origin: location.host
+  requireCollab: false
+  // origin is set in communicator.ts because it depends on browser
 } as const satisfies CommunicateConfig
 Object.freeze(defaultConfig)
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- バグ修正: SSR（サーバーサイドレンダリング）モードで"location"変数が定義されていない問題 (#42) を修正しました。これにより、`Communicator`クラスがメッセージを受信ウィンドウに送信する際のオリジンを指定できるようになりました。
- リファクタリング: `defaultConfig`オブジェクトから`origin`プロパティを削除しました。このプロパティはブラウザに依存するため、`communicator.ts`ファイルで設定されるようになりました。

これらの変更により、ソフトウェアの信頼性とパフォーマンスが向上することが期待されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->