### PR TITLE
ci(security): disable yarn lifecycle scripts (YARN_ENABLE_SCRIPTS=false)

### DIFF
--- a/.github/actions/init-node/action.yml
+++ b/.github/actions/init-node/action.yml
@@ -24,5 +24,7 @@ runs:
           node-modules--
 
     - if: steps.cache_node_modules.outputs.cache-hit != 'true'
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash


### PR DESCRIPTION
## 背景

npm エコシステムのサプライチェーン攻撃 (Mini Shai-Hulud 2nd 等) が継続しており、
CI runner 上で侵害版パッケージの `postinstall` / `preinstall` lifecycle script が実行されると、
GITHUB_TOKEN や npm token など各種 secret が外部に流出するリスクがある。

yarn berry には `--ignore-scripts` フラグが無いため、環境変数
`YARN_ENABLE_SCRIPTS=false` で同等の挙動になる。

## 変更

`.github/actions/init-node/action.yml` の `yarn --immutable` を実行する step に
`env: YARN_ENABLE_SCRIPTS: 'false'` を追加。

```diff
  - if: steps.cache_node_modules.outputs.cache-hit != 'true'
+   env:
+     YARN_ENABLE_SCRIPTS: 'false'
    run: yarn --immutable
    shell: bash
```

## 想定される影響

- `postinstall` で native build が必要な依存がある場合、CI が失敗する可能性
- 落ちた場合は yarn の `unplugged` 設定で個別 allow か、必要なら本 PR を revert

## 参考

- https://blog.flatt.tech/entry/mini_shai_hulud_2nd

🤖 Generated with [Claude Code](https://claude.com/claude-code)